### PR TITLE
fix(server): allow STDOUT#puts with no arguments (blank line)

### DIFF
--- a/gem/terminalwire-server/lib/terminalwire/server/resource.rb
+++ b/gem/terminalwire-server/lib/terminalwire/server/resource.rb
@@ -36,8 +36,8 @@ module Terminalwire::Server
     end
 
     class STDOUT < Base
-      def puts(data)
-        command("print_line", data: data)
+      def puts(data = nil)
+        command("print_line", data: data.to_s)
       end
 
       def print(data)

--- a/spec/integration/resources/stdout_spec.rb
+++ b/spec/integration/resources/stdout_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Terminalwire::Server::Resource::STDOUT do
     it 'prints line with newline to stdout through client' do
       expect { server_stdout.puts("Hello line") }.to output("Hello line\n").to_stdout
     end
+
+    it 'prints a blank line when called with no arguments' do
+      expect { server_stdout.puts }.to output("\n").to_stdout
+    end
+
+    it 'prints a blank line when called with nil' do
+      expect { server_stdout.puts(nil) }.to output("\n").to_stdout
+    end
   end
 
   describe '#flush' do


### PR DESCRIPTION
Fixes #6

## Problem

`Terminalwire::Server::Resource::STDOUT#puts` is declared with a required argument:

```ruby
def puts(data)
  command("print_line", data: data)
end
```

So calling `context.puts` with no arguments raises `ArgumentError: wrong number of arguments (given 0, expected 1)`. Ruby's stdlib `puts` with no args is valid and prints a blank line, so this is a surprising crash for an otherwise drop-in API.

## Fix

Make the argument optional and coerce with `to_s`, matching stdlib `puts` semantics (no args / `nil` → blank line):

```ruby
def puts(data = nil)
  command("print_line", data: data.to_s)
end
```

One-line change, plus two RSpec cases covering the no-arg and `nil` paths.

## Verified

The repo's integration suite uses `pty` (Linux pseudoterminal), which I can't run on my machine, so I verified the method logic directly:

```
BEFORE (def puts(data)):
  puts("Hello")  → "Hello"   PASS
  puts()         → ArgumentError: wrong number of arguments (given 0, expected 1)   ← bug
  puts(nil)      → ""         PASS

AFTER (def puts(data = nil)):
  puts("Hello")  → "Hello"   PASS
  puts()         → ""         PASS
  puts(nil)      → ""         PASS
```

---

Came across Terminalwire and noticed #6 had been open a while, so I went ahead and fixed it. No strings attached — I'm with Choreless and we like contributing real fixes to projects we use. If it's useful and you ever want a hand with something larger, happy to help.

— Charles
