### PR TITLE
fix(rails): unknown command should exit 1 and write to stderr

### DIFF
--- a/gem/terminalwire-rails/lib/terminalwire/rails.rb
+++ b/gem/terminalwire-rails/lib/terminalwire/rails.rb
@@ -172,7 +172,8 @@ module Terminalwire
                 cli.default_url_options[:host] = env["HTTP_HOST"]
               end
             rescue ::Thor::UndefinedCommandError, ::Thor::InvocationError => e
-              context.stdout.puts e.message
+              context.stderr.puts e.message
+              exit_code = 1
             rescue ::StandardError => e
               # Log the error
               handler_error_message = <<~ERROR


### PR DESCRIPTION
Fixes #10

## Problem

An unknown command always exits `0`. In `gem/terminalwire-rails/lib/terminalwire/rails.rb`, the rescue for `Thor::UndefinedCommandError` / `Thor::InvocationError` writes the message to **stdout** and never sets the exit code, so the `ensure` block always calls `context.exit 0`. Scripts and CI can't detect the failure.

```ruby
rescue ::Thor::UndefinedCommandError, ::Thor::InvocationError => e
  context.stdout.puts e.message
```

## Fix

Treat it like the `StandardError` handler right below it — error to **stderr**, exit code `1`:

```ruby
rescue ::Thor::UndefinedCommandError, ::Thor::InvocationError => e
  context.stderr.puts e.message
  exit_code = 1
```

Two-line change; mirrors the existing error-handling pattern in the same method.

## Verified

Standalone repro of the rescue/ensure path (Ruby 3.3):

```
                stdout                                   stderr   exit_code
BEFORE   "Could not find command \"foobar\".\n"          ""        0   ← bug
AFTER    ""                          "Could not find command \"foobar\".\n"   1
```

stderr routing + non-zero exit confirmed; normal commands unaffected.

---

Came across Terminalwire and noticed #10 had been open a while, so I went ahead and fixed it. No strings attached — I'm with Choreless and we like contributing real fixes to projects we use. If it's useful and you ever want a hand with something larger, happy to help.

— Charles
