### PR TITLE
v2/rails: delegate session from the CLI instance to the shell

### DIFF
--- a/v2/ruby/lib/terminalwire/v2/rails.rb
+++ b/v2/ruby/lib/terminalwire/v2/rails.rb
@@ -23,6 +23,13 @@ Terminalwire::V2::Server::Thor::Shell.class_eval do
   end
 end
 
+# Delegate `session` from the CLI instance to its shell — matching v1's
+# `def_delegators :shell, :session` — so unchanged Thor code that calls `session`
+# (current_user, login, whoami) works over v2 without app changes.
+Terminalwire::V2::Server::Thor::Helpers.module_eval do
+  def session = shell.session
+end
+
 module Terminalwire
   module V2
     # Drop-in Rails integration for serving a Terminalwire CLI over BOTH the v1


### PR DESCRIPTION
current_user/login/whoami call `session` on the Thor instance; the v2 shell has it (the session shim) but the instance didn't delegate. Adds `def session = shell.session` to the v2 Thor Helpers (matching v1's `def_delegators :shell, :session`). Verified: v2-only ogplus whoami returns the graceful 'must log in' instead of crashing.